### PR TITLE
Add simple plugin system

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,0 +1,16 @@
+# Plugin System
+
+This repository demonstrates a simple plugin architecture in Python. Plugins are
+located in the `plugins` directory and subclass `Plugin` from `plugin_base.py`.
+Use `plugin_manager.py` to load and run all plugins in the directory.
+
+## Usage
+
+```bash
+python3 - <<'PY'
+from plugin_manager import load_plugins, run_plugins
+
+plugins = load_plugins('plugins')
+run_plugins(plugins)
+PY
+```

--- a/plugin_base.py
+++ b/plugin_base.py
@@ -1,0 +1,6 @@
+class Plugin:
+    """Base class for plugins."""
+    name = "base"
+
+    def run(self, *args, **kwargs):
+        raise NotImplementedError("Plugin must implement run method")

--- a/plugin_manager.py
+++ b/plugin_manager.py
@@ -1,0 +1,23 @@
+import importlib
+import pkgutil
+from typing import List, Type
+
+from plugin_base import Plugin
+
+
+def load_plugins(package: str) -> List[Plugin]:
+    """Load all plugins in the given package."""
+    plugins: List[Plugin] = []
+    for loader, name, is_pkg in pkgutil.iter_modules([package]):
+        module = importlib.import_module(f"{package}.{name}")
+        for attribute_name in dir(module):
+            attribute = getattr(module, attribute_name)
+            if isinstance(attribute, type) and issubclass(attribute, Plugin) and attribute is not Plugin:
+                plugins.append(attribute())
+    return plugins
+
+
+def run_plugins(plugins: List[Plugin]):
+    for plugin in plugins:
+        print(f"Running plugin: {plugin.name}")
+        plugin.run()

--- a/plugins/example_plugin.py
+++ b/plugins/example_plugin.py
@@ -1,0 +1,7 @@
+from plugin_base import Plugin
+
+class ExamplePlugin(Plugin):
+    name = "example"
+
+    def run(self):
+        print("Hello from ExamplePlugin!")


### PR DESCRIPTION
## Summary
- add base Plugin class
- implement plugin manager to load and run plugins
- add example plugin
- document usage in README

## Testing
- `python3 - <<'PY'
from plugin_manager import load_plugins, run_plugins
plugins = load_plugins('plugins')
run_plugins(plugins)
PY
`

------
https://chatgpt.com/codex/tasks/task_e_683fc8b7177c83279c03000ce25eeb91